### PR TITLE
Fix: Changed getNotification() in android and passed data in iOS

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
@@ -29,8 +29,8 @@ public class ReactNativeFirebaseMessagingReceiver extends BroadcastReceiver {
     RemoteMessage remoteMessage = new RemoteMessage(intent.getExtras());
     ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();
 
-    // Add a RemoteMessage if the message contains a notification payload
-    if (remoteMessage.getNotification() != null) {
+    // Add a RemoteMessage if the message contains a data payload
+    if (!remoteMessage.getData().isEmpty()) {
       notifications.put(remoteMessage.getMessageId(), remoteMessage);
       ReactNativeFirebaseMessagingStoreHelper.getInstance()
           .getMessagingStore()

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -104,6 +104,15 @@
     }
     data[key] = userInfo[key];
   }
+      // Append apsDict[@"data"] if it exists
+    if (userInfo[@"aps"] != nil) {
+      NSDictionary *apsDict = userInfo[@"aps"];
+      
+      if (apsDict[@"data"] != nil && [apsDict[@"data"] isKindOfClass:[NSDictionary class]]) {
+        [data addEntriesFromDictionary:apsDict[@"data"]];
+      }
+    }
+    
   message[@"data"] = data;
 
   if (userInfo[@"aps"] != nil) {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues
🔥 messaging().onNotificationOpenedApp is never triggered, messaging().getInitialNotification() is triggered but remoteMessage is always null

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

- Changed checking notification payload to data payload in android
- Passed data field in remoteMessage in iOS

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
